### PR TITLE
fix(audio): Make audio loading resilient to errors

### DIFF
--- a/src/engine/AudioManager.js
+++ b/src/engine/AudioManager.js
@@ -44,7 +44,8 @@ export class AudioManager {
 
     async loadSounds(sounds) {
         const promises = sounds.map(sound => this.loadSound(sound.name, sound.path));
-        await Promise.all(promises);
+        // Используем allSettled, чтобы одна неудачная загрузка не прервала все остальные.
+        await Promise.allSettled(promises);
     }
 
     playSound(name, playbackRate = 1.0) {


### PR DESCRIPTION
This commit modifies the `AudioManager` to use `Promise.allSettled` instead of `Promise.all` when loading multiple sounds.

Previously, if a single audio file was corrupt or failed to load (due to an `EncodingError` or other issue), `Promise.all` would reject and crash the entire game's startup sequence. This made the main menu buttons appear unresponsive.

By switching to `Promise.allSettled`, the game will now continue to load even if some non-critical audio assets fail. This makes the game more robust and prevents a total failure due to a single faulty asset.