### PR TITLE
fix(input): Centralize UI input handling to fix unresponsive menu but…

### DIFF
--- a/src/engine/InputHandler.js
+++ b/src/engine/InputHandler.js
@@ -16,31 +16,52 @@ export class InputHandler {
             this.keys.delete(e.code);
         });
 
+        // --- Мышь ---
+        this.canvas.addEventListener('click', (e) => {
+            // Мышь используется только для UI в меню
+            if (['mainMenu', 'settings'].includes(this.ui.game.gameState)) {
+                this.ui.handleMouseClick(e.offsetX, e.offsetY);
+            }
+        });
+
         // --- Сенсорное управление ---
         if (this.ui.isTouchDevice) {
             this.canvas.addEventListener('touchstart', (e) => {
-                e.preventDefault();
                 const rect = this.canvas.getBoundingClientRect();
-                for (const touch of e.changedTouches) {
-                    const x = (touch.clientX - rect.left) * (this.canvas.width / rect.width);
-                    const y = (touch.clientY - rect.top) * (this.canvas.height / rect.height);
+                const scaleX = this.canvas.width / rect.width;
+                const scaleY = this.canvas.height / rect.height;
 
-                    for (const buttonName in this.ui.touchControls) {
-                        const btn = this.ui.touchControls[buttonName];
-                        // Простая проверка столкновения точки с кругом
-                        const dx = x - (btn.x + btn.width / 2);
-                        const dy = y - (btn.y + btn.height / 2);
-                        if (dx * dx + dy * dy < (btn.width / 2) * (btn.width / 2)) {
-                            // Специальная обработка для прыжка
-                            if (btn.key === 'Space') {
-                                if (this.ui.game.player) {
-                                    this.ui.game.player.jump();
+                // В меню, касания эмулируют клики по UI
+                if (['mainMenu', 'settings'].includes(this.ui.game.gameState)) {
+                    e.preventDefault(); // Предотвращаем генерацию click, чтобы не было двойного срабатывания
+                    for (const touch of e.changedTouches) {
+                        const x = (touch.clientX - rect.left) * scaleX;
+                        const y = (touch.clientY - rect.top) * scaleY;
+                        this.ui.handleMouseClick(x, y);
+                    }
+                    return; // Завершаем, так как в меню не нужны игровые контролы
+                }
+
+                // В игре, касания управляют персонажем
+                if (this.ui.game.gameState === 'playing') {
+                    e.preventDefault();
+                    for (const touch of e.changedTouches) {
+                        const x = (touch.clientX - rect.left) * scaleX;
+                        const y = (touch.clientY - rect.top) * scaleY;
+
+                        for (const buttonName in this.ui.touchControls) {
+                            const btn = this.ui.touchControls[buttonName];
+                            const dx = x - (btn.x + btn.width / 2);
+                            const dy = y - (btn.y + btn.height / 2);
+                            if (dx * dx + dy * dy < (btn.width / 2) * (btn.width / 2)) {
+                                if (btn.key === 'Space') {
+                                    if (this.ui.game.player) this.ui.game.player.jump();
+                                } else {
+                                    this.keys.add(btn.key);
                                 }
-                            } else {
-                                this.keys.add(btn.key);
+                                this.activeTouches.set(touch.identifier, btn.key);
+                                break;
                             }
-                            this.activeTouches.set(touch.identifier, btn.key);
-                            break; // Одно касание может активировать только одну кнопку
                         }
                     }
                 }

--- a/src/main.js
+++ b/src/main.js
@@ -186,12 +186,6 @@ window.addEventListener('load', async function() {
                 }
             });
 
-            canvas.addEventListener('click', (e) => {
-                if (this.ui.isReady()) {
-                    this.ui.handleMouseClick(e.offsetX, e.offsetY);
-                }
-            }, { capture: true });
-
             canvas.addEventListener('touchstart', () => this.audioManager.init(), { once: true });
         }
     };


### PR DESCRIPTION
…tons

The main menu and settings buttons were unresponsive to both mouse clicks and touch events. This was caused by a combination of issues:
- A `click` event listener in `main.js` was being prevented from firing on touch-enabled devices due to a `preventDefault()` call in the `touchstart` listener in `InputHandler.js`.
- There was no explicit touch handling for UI elements, only for in-game controls.

This commit refactors the input handling to solve the issue:
- All canvas-related input listeners (`click`, `touchstart`) are now centralized within `InputHandler.js`.
- The old `click` listener is removed from `main.js`.
- The `InputHandler` now inspects the `gameState` to intelligently route input. If the game is in a menu state ('mainMenu', 'settings'), clicks and touches are forwarded to the UI handler. If the game is in the 'playing' state, touch events are used for the on-screen game controls.

This ensures that both mouse and touch inputs work correctly and reliably for all UI elements and game controls.