### PR TITLE
fix(game): Resolve gameplay loop and restart issues

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -193,12 +193,24 @@ window.addEventListener('load', function() {
     // --- Основной игровой цикл ---
     let lastTime = 0;
     function gameLoop(timestamp) {
+        // Инициализируем lastTime на первом кадре, чтобы избежать огромного deltaTime
+        if (lastTime === 0) {
+            lastTime = timestamp;
+            requestAnimationFrame(gameLoop);
+            return;
+        }
+
         const rawDeltaTime = timestamp - lastTime;
         lastTime = timestamp;
 
         // Не обновляем логику если игра не в фокусе или на паузе
         if (game.gameState === 'playing') {
             game.update(rawDeltaTime);
+        } else if (game.gameState === 'gameOver') {
+            if (game.inputHandler.keys.has('Enter')) {
+                game.inputHandler.keys.delete('Enter'); // Сразу удаляем, чтобы не было многократного срабатывания
+                game.startGame();
+            }
         }
 
         game.draw();


### PR DESCRIPTION
This commit includes two critical fixes to the game logic:

1.  **Fixes instant death on start:** The game loop's `deltaTime` was not initialized correctly, causing a massive time step on the first frame that would make the player fall out of the world. The loop now safely initializes the timer on the first frame.
2.  **Fixes non-functional restart:** Input was not being processed in the 'gameOver' state. The game loop now checks for the 'Enter' key press during 'gameOver' to correctly trigger a restart.