### PR TITLE
feat: Add diagnostic hack to force grounded state

### DIFF
--- a/src/game/Player.js
+++ b/src/game/Player.js
@@ -69,6 +69,13 @@ export class Player {
         // ИСПРАВЛЕНО: Передаем dt
         this.handleCollisions('vertical', level.tiles, doors, platforms, dt);
 
+        // HACK: Force ground state for debugging
+        if (this.frameCount < 10 && this.position.y > 319) {
+            this.isGrounded = true;
+            this.velocity.y = 0;
+            this.position.y = 320;
+        }
+
         if (this.onPlatform) {
             this.position.x += this.onPlatform.velocity.x * this.onPlatform.direction * dt;
         }


### PR DESCRIPTION
This is a temporary hack for debugging. It forces the player into a grounded state when they are near the ground for the first 10 frames.

This is intended to bypass the faulty collision detection to see if there are other underlying issues causing the game to end or the player to be invisible.